### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"type" : "git",
 		"url" : "https://github.com/keeganstreet/specificity.git"
 	},
+	"license": "MIT",
 	"bugs": {
 		"url": "https://github.com/keeganstreet/specificity/issues"
 	},


### PR DESCRIPTION
You mentioned in keeganstreet/specificity#2 that people were free to distribute this code, but our legal team wants to be sure everything is above board with a license. Does the MIT license work for you?
