### PR TITLE
Specificity is node version agnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
 		"url": "https://github.com/keeganstreet/specificity/issues"
 	},
 	"main": "specificity",
-	"engines": {
-		"node": "~0.8.x"
-	},
 	"scripts": {
 		"test": "node_modules/.bin/mocha test/test.js"
 	},


### PR DESCRIPTION
I am trying to run in on node 0.10 and have warnings during installation.