### PR TITLE
Added a compare function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Specificity Calculator
 
-A JavaScript module for calculating the [specificity of CSS selectors](http://www.w3.org/TR/css3-selectors/#specificity). The module is used on the [Specificity Calculator](http://specificity.keegan.st/) website.
+A JavaScript module for calculating and comparing the [specificity of CSS selectors](http://www.w3.org/TR/css3-selectors/#specificity). The module is used on the [Specificity Calculator](http://specificity.keegan.st/) website.
 
 Specificity Calculator is built for CSS Selectors Level 3. Specificity Calculator isn’t a CSS validator. If you enter invalid selectors it will return incorrect results. For example, the [negation pseudo-class](http://www.w3.org/TR/css3-selectors/#negation) may only take a simple selector as an argument. Using a psuedo-element or combinator as an argument for `:not()` is invalid CSS3 so Specificity Calculator will return incorrect results.
 

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ console.log(result);
 [ {
     selector: 'ul#nav li.active a',
     specificity: '0,1,1,3',
+    specificityArray: [0, 1, 1, 3],
     parts: [
       { selector: 'ul', type: 'c', index: 0, length: 2 },
       { selector: '#nav', type: 'a', index: 2, length: 4 },

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,28 @@ console.log(result);
 */
 ```
 
+## Comparing two selectors
+
+Specificity Calculator also exposes a `compare` function. This function accepts two CSS selectors, `a` and `b`.
+
+  * It returns `-1` if `a` has a lower specificity than `b`
+  * It returns `1` if `a` has a higher specificity than `b`
+  * It returns `0` if `a` has the same specificity than `b`
+
+```js
+SPECIFICITY.compare('div', '.active');   // -1
+SPECIFICITY.compare('#main', 'div');     // 1
+SPECIFICITY.compare('span', 'div');      // 0
+```
+
+## Ordering an array of selectors by specificity
+
+You can pass the `SPECIFICITY.compare` function to `Array.prototype.sort` to sort an array of CSS selectors by specificity.
+
+```js
+['#main', 'p', '.active'].sort(SPECIFICITY.compare);   // ['p', '.active', '#main']
+```
+
 ## Testing
 
 To test this package, install dependencies: `npm install`

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ SPECIFICITY.calculate('ul#nav li.active a, body.ie7 .col_3 h2 ~ h2');   // [{ sp
 The `specificity.calculate` function returns an array containing a result object for each selector input. Each result object has the following properties:
 
   * `selector`: the input
-  * `specificity`: the result e.g. `0,1,0,0`
+  * `specificity`: the result as a string e.g. `0,1,0,0`
+  * `specificityArray`: the result as an array of numbers e.g. `[0, 1, 0, 0]`
   * `parts`: array with details about each part of the selector that counts towards the specificity
 
 ## Example

--- a/specificity.js
+++ b/specificity.js
@@ -1,16 +1,9 @@
-/**
- * Calculates the specificity of CSS selectors
- * http://www.w3.org/TR/css3-selectors/#specificity
- *
- * Returns an array of objects with the following properties:
- *  - selector: the input
- *  - specificity: e.g. 0,1,0,0
- *  - parts: array with details about each part of the selector that counts towards the specificity
- */
 var SPECIFICITY = (function() {
 	var calculate,
-		calculateSingle;
+		calculateSingle,
+		compare;
 
+	// Calculate the specificity for a selector by dividing it into simple selectors and counting them
 	calculate = function(input) {
 		var selectors,
 			selector,
@@ -31,7 +24,16 @@ var SPECIFICITY = (function() {
 		return results;
 	};
 
-	// Calculate the specificity for a selector by dividing it into simple selectors and counting them
+	/**
+	 * Calculates the specificity of CSS selectors
+	 * http://www.w3.org/TR/css3-selectors/#specificity
+	 *
+	 * Returns an object with the following properties:
+	 *  - selector: the input
+	 *  - specificity: e.g. 0,1,0,0
+	 *  - parts: array with details about each part of the selector that counts towards the specificity
+	 *  - specificityArray: e.g. [0, 1, 0, 0]
+	 */
 	calculateSingle = function(input) {
 		var selector = input,
 			findMatch,
@@ -131,16 +133,53 @@ var SPECIFICITY = (function() {
 		return {
 			selector: input,
 			specificity: '0,' + typeCount.a.toString() + ',' + typeCount.b.toString() + ',' + typeCount.c.toString(),
+			specificityArray: [0, typeCount.a, typeCount.b, typeCount.c],
 			parts: parts
 		};
 	};
 
+	/**
+	 * Compares two CSS selectors for specificity
+	 *
+	 *  - it returns -1 if a has a lower specificity than b
+	 *  - it returns 1 if a has a higher specificity than b
+	 *  - it returns 0 if a has the same specificity than b
+	 */
+	compare = function(a, b) {
+		var aSpecificity,
+			bSpecificity,
+			i;
+
+		if (a.indexOf(',') !== -1) {
+			throw a + ' is not a valid CSS selector';
+		}
+
+		if (b.indexOf(',') !== -1) {
+			throw b + ' is not a valid CSS selector';
+		}
+
+		aSpecificity = calculateSingle(a)['specificityArray'];
+		bSpecificity = calculateSingle(b)['specificityArray'];
+
+		for (i = 0; i < 4; i += 1) {
+			if (aSpecificity[i] < bSpecificity[i]) {
+				return -1;
+			} else if (aSpecificity[i] > bSpecificity[i]) {
+				return 1;
+			}
+		}
+
+		return 0;
+	};
+
 	return {
-		calculate: calculate
+		calculate: calculate,
+		compare: compare
 	};
 }());
 
 // Export for Node JS
 if (typeof exports !== 'undefined') {
 	exports.calculate = SPECIFICITY.calculate;
+	exports.compare = SPECIFICITY.compare;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,9 @@
 var specificity = require('../'),
 	assert = require('assert'),
 	tests,
-	testSelector;
+	testSelector,
+	comparisonTests,
+	testCompare;
 
 tests = [
 	// http://css-tricks.com/specifics-on-css-specificity/
@@ -33,18 +35,70 @@ tests = [
 ];
 
 testSelector = function(test) {
-	describe('#calculate("' + test.selector + '")', function() {
-		it ('should return a specificity of "' + test.expected + '"', function() {
-			var result = specificity.calculate(test.selector);
-			assert.equal(result[0].specificity, test.expected);
-		});
+	it('calculate("' + test.selector + '") should return a specificity of "' + test.expected + '"', function() {
+		var result = specificity.calculate(test.selector);
+		assert.equal(result[0].specificity, test.expected);
+	});
+};
+
+comparisonTests = [
+	{ a: 'div', b: 'span', expected: 0 },
+	{ a: '.active', b: ':focus', expected: 0 },
+	{ a: '#header', b: '#main', expected: 0 },
+	{ a: 'div', b: '.active', expected: -1 },
+	{ a: 'div', b: '#header', expected: -1 },
+	{ a: '.active', b: '#header', expected: -1 },
+	{ a: '.active', b: 'div', expected: 1 },
+	{ a: '#main', b: 'div', expected: 1 },
+	{ a: '#main', b: ':focus', expected: 1 },
+	{ a: 'div p', b: 'span a', expected: 0 },
+	{ a: '#main p .active', b: '#main span :focus', expected: 0 },
+	{ a: ':focus', b: 'span a', expected: 1 },
+	{ a: '#main', b: 'span a:hover', expected: 1 },
+	{ a: 'ul > li > a > span:before', b: '.active', expected: -1 },
+	{ a: 'a.active:hover', b: '#main', expected: -1 }
+];
+
+testCompare = function(test) {
+	it('compare("' + test.a + '", "' + test.b + '") should return ' + test.expected, function() {
+		var result = specificity.compare(test.a, test.b);
+		assert.equal(result, test.expected);
 	});
 };
 
 describe('specificity', function() {
-	var i, len, test;
-	for (i = 0, len = tests.length; i < len; i += 1) {
-		test = tests[i];
-		testSelector(test);
-	}
+	describe('calculate', function() {
+		var i, len, test;
+
+		for (i = 0, len = tests.length; i < len; i += 1) {
+			test = tests[i];
+			testSelector(test);
+		}
+	});
+
+	describe('compare', function() {
+		var i, len, test;
+
+		for (i = 0, len = comparisonTests.length; i < len; i += 1) {
+			test = comparisonTests[i];
+			testCompare(test);
+		}
+	});
+
+	describe('sorting with compare', function() {
+		var a = 'div',
+			b = 'p a',
+			c = '.active',
+			d = 'p.active',
+			e = '.active:focus',
+			f = '#main',
+			original = [c, f, a, e, b, d],
+			sorted = [a, b, c, d, e, f];
+
+		it('array.sort(specificity.compare) should sort the array by specificity', function() {
+			var result = original.sort(specificity.compare);
+
+			assert.equal(result.join('|'), sorted.join('|'));
+		});
+	});
 });


### PR DESCRIPTION
## Comparing two selectors

Specificity Calculator now exposes a `compare` function. This function accepts two CSS selectors, `a` and `b`.

  * It returns `-1` if `a` has a lower specificity than `b`
  * It returns `1` if `a` has a higher specificity than `b`
  * It returns `0` if `a` has the same specificity than `b`

```js
SPECIFICITY.compare('div', '.active');   // -1
SPECIFICITY.compare('#main', 'div');     // 1
SPECIFICITY.compare('span', 'div');      // 0
```

## Ordering an array of selectors by specificity

You can pass the `SPECIFICITY.compare` function to `Array.prototype.sort` to sort an array of CSS selectors by specificity.