### PR TITLE
Fix a parse error on ie8.

### DIFF
--- a/specificity.js
+++ b/specificity.js
@@ -112,7 +112,7 @@ var SPECIFICITY = (function() {
 
 		// Remove anything after a left brace in case a user has pasted in a rule, not just a selector
 		(function() {
-			var regex = new RegExp('{[^]*', 'gm'),
+			var regex = /{(?:.|\s)*/gm,
 				matches, i, len, match;
 			if (regex.test(selector)) {
 				matches = selector.match(regex);

--- a/specificity.js
+++ b/specificity.js
@@ -112,7 +112,7 @@ var SPECIFICITY = (function() {
 
 		// Remove anything after a left brace in case a user has pasted in a rule, not just a selector
 		(function() {
-			var regex = /{[^]*/gm,
+			var regex = new RegExp('{[^]*', 'gm'),
 				matches, i, len, match;
 			if (regex.test(selector)) {
 				matches = selector.match(regex);


### PR DESCRIPTION
Currently, when trying to load specificity in ie8, the script will fail to parse due to this line of regex: 
`var regex = /{[^]*/gm,`

Changing from literal to constructor notation allows the script to be parsed on ie8.  

Note that this is not intended to make the script work on ie8, but at least it won't throw an error while loading the file.
