### PR TITLE
Fixed the problem that selector includes space.

### DIFF
--- a/specificity.js
+++ b/specificity.js
@@ -15,7 +15,7 @@ var SPECIFICITY = (function() {
 		selectors = input.split(',');
 
 		for (i = 0, len = selectors.length; i < len; i += 1) {
-			selector = selectors[i];
+			selector = selectors[i].trim();
 			if (selector.length > 0) {
 				results.push(calculateSingle(selector));
 			}


### PR DESCRIPTION
SPECIFICITY.calculate('.hoge, .fuga')[0].selector;//.hoge
SPECIFICITY.calculate('.hoge, .fuga')[1].selector;// .fuga <<< space at prefix

I love this your framework! I'm using this on my works like below :)
http://style-validator.io/
https://github.com/igari/get-specified-style.js