### PR TITLE
Add TypeScript definition for the public API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
   },
   "devDependencies": {
     "mocha": "2.5.x"
-  }
+  },
+  "types": "specificity.d.ts"
 }

--- a/specificity.d.ts
+++ b/specificity.d.ts
@@ -1,0 +1,56 @@
+declare module "specificity" {
+  export = specificity;
+  namespace specificity {
+    /**
+     * Specificity arrays always have 4 numbers (integers) for quick comparison
+     * comparing from left to right, the next number only has to be checked if
+     * two numbers of the same index are equal.
+     */
+    type SpecificityArray = [number, number, number, number];
+
+    /**
+     * A result of parsing a selector into an array of parts.
+     * Calculating a specificity array is a matter of summing
+     * over all the parts and adding the values to the right
+     * bucket in a specificity array.
+     * 
+     * @interface Part
+     */
+    interface Part {
+      selector: string;
+      type: "a" | "b" | "c";
+      index: number;
+      length: number;
+    }
+    /**
+     * Returned by the calculate function. Represents the results
+     * of parsing and calculating the specificity of a selector.
+     * 
+     * @interface Specificity
+     */
+    interface Specificity {
+      selector: string;
+      specificity: string;
+      specificityArray: SpecificityArray;
+      parts: Array<Part>;
+    }
+    /**
+     * Calculates the specificity for the given selector string.
+     * If the string contains a comma, each selector will be parsed
+     * separately.
+     * 
+     * @returns A list of specificity objects one for each selector in the
+     * selector string.
+     */
+    function calculate(selector: string): Array<Specificity>;
+
+    /**
+     * Compares two selectors. If a string, the string cannot contain a comma.
+     * 
+     * @returns A value less than 0 if selector a is less specific than selector b.
+     *   A value more than 0 if selector a is more specific than selector b.
+     *   0 if the two selectors have the same specificity.
+     */
+    function compare(a: string | SpecificityArray, b: string | SpecificityArray): -1 | 0 | 1;
+  }
+}


### PR DESCRIPTION
Hi, I use this project with a project written in typescript so I made a typescript definition for it.

If you're not familiar with typescript there's two approaches to adding a public definition file. The preferred approach is to add it to the project and ship with it. This way new changes to the API can be kept in sync. The second approach is that this definition can be shipped as a separate node module and maintained by the typescript community at https://github.com/DefinitelyTyped/DefinitelyTyped

If you're not interested in accepting this PR then please let me know and I'll take the community driven approach instead. If you are, and would like help maintaining the typescript definition when the public API changes, I'm willing to do so.